### PR TITLE
Issue #33 - Choose a new team control is difficult to see in iOS

### DIFF
--- a/screens/messages-screen/new-message.js
+++ b/screens/messages-screen/new-message.js
@@ -133,7 +133,6 @@ class NewMessage extends Component {
                                         <Text style={styles.labelDark}>Select Team to Message:</Text>
                                         <Picker
                                             style={styles.picker}
-                                            itemStyle={{height: 45}}
                                             selectedValue={teamValue}
                                             onValueChange={(itemValue) => this.setState({selectedTeamId: itemValue})}>
                                             {items}


### PR DESCRIPTION
This seems to have been an iOS only issue, caused by a style that seemed to be hiding the other picker items from showing.
This seemed the most obvious solution to me, though there may have been a good reason for putting that style there in the first place. Another possibility is looking another control entirely, like https://github.com/alinz/react-native-dropdown for example.

