### PR TITLE
Initial Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,6 @@
 tasks:
+# The init task didn't seem to be working. Replaced with hints from
+# https://www.gitpod.io/blog/gitpodify/
 - before: >
       npm install &&
       npm install -g expo-cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 tasks:
-- before: npm install -g expo-cli
-  init: yarn install
+- before: >
+      npm install &&
+      npm install -g expo-cli
   command: expo start --host tunnel
 
 ports:

--- a/gitpod.yml
+++ b/gitpod.yml
@@ -1,0 +1,12 @@
+tasks:
+- before: npm install -g expo-cli
+  init: yarn install
+  command: expo start --host tunnel
+
+ports:
+- port: 19000-19002
+  onOpen: ignore
+- port: 4040
+  onOpen: ignore
+- port: 5037
+  onOpen: ignore


### PR DESCRIPTION
Add an initial Gitpod configuration file to install Expo, start it, and sliently open ports.

Fixes codeforbtv/green-up-app#171