### PR TITLE
Disable TypeScript checking

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,4 +1,5 @@
 {
    "flow.pathToFlow": "${workspaceRoot}/node_modules/.bin/flow",
    "typescript.tsdk": "node_modules/typescript/lib",
+   "javascript.validate.enable": false,
 }


### PR DESCRIPTION
Gitpod now uses the Visual Studio Code TypeScript extension rather than a custom one, so we can disable TypeScript checking

Fixes codeforbtv/green-up-app#173