### PR TITLE
220 login hidden under keyboard

### DIFF
--- a/screens/create-new-account-screen/index.js
+++ b/screens/create-new-account-screen/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from "react";
-import { StyleSheet, SafeAreaView } from "react-native";
+import { StyleSheet, SafeAreaView, ScrollView } from "react-native";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import CreateAccountForm from "../../components/create-account-form";
@@ -22,13 +22,15 @@ type PropsType = {
 
 const Index = ({ actions, createUserError }: PropsType): React$Element<any> => (
     <SafeAreaView style={ styles.container }>
-        <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, paddingTop: 50 } }>
-            <CreateAccountForm
-                buttonText="Create Account"
-                createUserError={ createUserError }
-                createAccount={ actions.createUser }
-            />
-        </View>
+        <ScrollView keyboardShouldPersistTaps="handled" scrollEnabled={ false }>
+            <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, paddingTop: 50 } }>
+                <CreateAccountForm
+                    buttonText="Create Account"
+                    createUserError={ createUserError }
+                    createAccount={ actions.createUser }
+                />
+            </View>
+        </ScrollView>
     </SafeAreaView>
 );
 

--- a/screens/login-screen/index.js
+++ b/screens/login-screen/index.js
@@ -7,7 +7,8 @@ import {
     Alert,
     Image,
     StyleSheet,
-    SafeAreaView
+    SafeAreaView,
+    ScrollView
 } from "react-native";
 import { View, Button, Text, Divider } from "@shoutem/ui";
 import * as actionCreators from "../../action-creators/session-action-creators";
@@ -83,61 +84,63 @@ type PropsType = {
 
 const Login = ({ actions, loginError, navigation }: PropsType): React$Element<any> => (
     <SafeAreaView style={ styles.container }>
-        { loginError
-            ? Alert.alert(
-                "",
-                (loginError.message || "Login Failed"),
-                [
-                    {
-                        text: "OK", onPress: () => {
+        <ScrollView keyboardShouldPersistTaps="handled" scrollEnabled={ false }>
+            { loginError
+                ? Alert.alert(
+                    "",
+                    (loginError.message || "Login Failed"),
+                    [
+                        {
+                            text: "OK", onPress: () => {
+                            }
                         }
-                    }
-                ],
-                { cancelable: false }
-            ) : null
-        }
+                    ],
+                    { cancelable: false }
+                ) : null
+            }
 
-        <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1 } }>
-            <View style={ styles.logo }>
-                <Image source={ logo } style={ { height: 120, width: 120 } }/>
-            </View>
-            <View style={ { width: "100%" } }>
-                <LoginForm onButtonPress={ actions.loginWithEmailPassword }/>
-                <Divider styleName="line"/>
-                <View style={ { marginTop: 40 } } styleName="horizontal">
-                    <Button
-                        onPress={ () => {
-                            navigation.navigate("ForgotPassword");
-                        } }
-                        style={ { paddingLeft: 20, paddingRight: 20 } }
-                        styleName="confirmation secondary"
-                    >
-                        <MaterialCommunityIcons
-                            name={ "account-convert" }
-                            size={ 25 }
-                            style={ { marginRight: 10 } }
-                            color="#FFF"
-                        />
-                        <Text>RESET PASSWORD</Text>
-                    </Button>
-                    <Button
-                        onPress={ () => {
-                            navigation.navigate("CreateNewAccount");
-                        } }
-                        style={ { paddingLeft: 20, paddingRight: 20 } }
-                        styleName="confirmation secondary"
-                    >
-                        <MaterialCommunityIcons
-                            name={ "account-plus" }
-                            size={ 25 }
-                            style={ { marginRight: 10 } }
-                            color="#FFF"
-                        />
-                        <Text style={ styles.buttonText }>CREATE ACCOUNT</Text>
-                    </Button>
+            <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1 } }>
+                <View style={ styles.logo }>
+                    <Image source={ logo } style={ { height: 120, width: 120 } }/>
+                </View>
+                <View style={ { width: "100%" } }>
+                    <LoginForm onButtonPress={ actions.loginWithEmailPassword }/>
+                    <Divider styleName="line"/>
+                    <View style={ { marginTop: 40 } } styleName="horizontal">
+                        <Button
+                            onPress={ () => {
+                                navigation.navigate("ForgotPassword");
+                            } }
+                            style={ { paddingLeft: 20, paddingRight: 20 } }
+                            styleName="confirmation secondary"
+                        >
+                            <MaterialCommunityIcons
+                                name={ "account-convert" }
+                                size={ 25 }
+                                style={ { marginRight: 10 } }
+                                color="#FFF"
+                            />
+                            <Text>RESET PASSWORD</Text>
+                        </Button>
+                        <Button
+                            onPress={ () => {
+                                navigation.navigate("CreateNewAccount");
+                            } }
+                            style={ { paddingLeft: 20, paddingRight: 20 } }
+                            styleName="confirmation secondary"
+                        >
+                            <MaterialCommunityIcons
+                                name={ "account-plus" }
+                                size={ 25 }
+                                style={ { marginRight: 10 } }
+                                color="#FFF"
+                            />
+                            <Text style={ styles.buttonText }>CREATE ACCOUNT</Text>
+                        </Button>
+                    </View>
                 </View>
             </View>
-        </View>
+        </ScrollView>
     </SafeAreaView>
 );
 


### PR DESCRIPTION
Workaround for #220 and #224  as it allows you to dismiss the keyboard by tapping outside of the inputs in the login and create account screens.

Quite a [long thread about this issue here](https://stackoverflow.com/questions/29685421/hide-keyboard-in-react-native) with multiple solutions being proposed

## Discussion

- We could wrap a `ScrollView` around the entire app so we don't have to do this for each screen. I was a bit anxious about making a change like this to the entire app due to the risk that it could break lots of things.
- We could use `<View onStartShouldSetResponder={() => {
   Keyboard.dismiss();
   return false;
}}` potentially wrapped around the whole app, not clear how this is different to the non-scrollable ScrollView approach
- We could use `<TouchableWithoutFeedback onPress={Keyboard.dismiss}>` although someone notes in the stack overflow thread above notes that that "Wrapping your components in a TouchableWithoutFeedback can cause some weird scroll behavior and other issues" so some FUD here
- A completely different direction would be to use `KeyboardAvoidingView ` as was done here https://github.com/codeforbtv/cvoeo-app/pull/139 but I tried wrapping this around the login screen and it did not have any effect in the emulator (it did not shift the content when the keyboard opened). Perhaps it is interacting with some styles in this project?

## Known Issues

On iPhone 6 emulator, when I tab from email to password field, tapping outside to close no longer works but I am using my keyboard to tab so this is probably not something a real user would be able to do.