### PR TITLE
Fix "Add from Contacts" crash

### DIFF
--- a/components/invite-contacts/index.js
+++ b/components/invite-contacts/index.js
@@ -68,7 +68,7 @@ const InviteContacts = ({ actions, closeModal, contacts, currentUser, selectedTe
     };
 
 
-    const filterSortContacts = myContacts => myContacts
+    const filterSortContacts = myContacts => (myContacts || [])
         .filter((contact: ContactType): boolean => isValidEmail(contact.email || "") && !isInTeam(teamMembers[selectedTeam.id], contact.email))
         .sort((a: ContactType, b: ContactType): number => {
             const bDisplay = (`${ b.firstName || "" }${ b.lastName || "" }${ b.email || "" }`).toLowerCase();


### PR DESCRIPTION
Don't think we have an issue open for it, but this will fix the crash that happens when you click "Add from Contacts" in team detail page