### PR TITLE
key for leaderboard rows

### DIFF
--- a/screens/leaderboard-screen/index.js
+++ b/screens/leaderboard-screen/index.js
@@ -148,6 +148,7 @@ const LeaderboardScreen = ({ rankings }: PropsType): React$Element<any> => {
                 style={ { marginTop: 51 } }
                 data={ sortedRanks }
                 renderItem={ renderRow }
+                keyExtractor={(teamRow) => teamRow.teamId }
             />
         </SafeAreaView>
     );


### PR DESCRIPTION
Supplied keyExtractor to fix warning message.

<img src="https://user-images.githubusercontent.com/1809882/77384018-bfc40400-6d5a-11ea-9281-89da66aee93e.png" width=300/>