### PR TITLE
Publish date

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "version": "3.0.1",
+  "publishDate": "3.24.20",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/screens/menu-screen/index.js
+++ b/screens/menu-screen/index.js
@@ -8,6 +8,7 @@ import { defaultStyles } from "../../styles/default-styles";
 import * as constants from "../../styles/constants";
 import { Text, Button, View } from "@shoutem/ui";
 import { MaterialCommunityIcons, Octicons } from "@expo/vector-icons";
+import { publishDate } from '../../package.json';
 
 const myStyles = {};
 const combinedStyles = Object.assign({}, defaultStyles, myStyles);
@@ -78,6 +79,10 @@ const MenuScreen = ({ actions, navigation }: PropsType): React$Element<View> => 
                 <Text style={ { ...styles.buttonText, fontSize } }>{ "Log Out" }</Text>
             </Button>
         </View>
+        <View style={ { margin: 20 } }>
+            <Text style={ { fontSize: 16, color:'#7fa54a', textAlign: 'center' } }>{ `v${publishDate}` }</Text>
+        </View>
+
     </SafeAreaView>);
 };
 


### PR DESCRIPTION
Adds the publish date to 'menu' screen so QA can quickly tell if they are looking at a current version of the app.

This date will need to be manually updated in the package.json file though, JFYI.

<img src="https://user-images.githubusercontent.com/1809882/77497717-5f999480-6e24-11ea-911a-330988740963.png" width=300/>
