### PR TITLE
Refactor trash info component

### DIFF
--- a/components/disposal-site-selector/disposal-site-selector.js
+++ b/components/disposal-site-selector/disposal-site-selector.js
@@ -38,7 +38,7 @@ export const DisposalSiteSelector = ({ userLocation, townInfo }: PropsType): Rea
     return (
         <Fragment>
             <SearchBar
-                help={ <TrashInfo greenUpStartDate={greenUpStartDate} greenUpEndDate={greenUpEndDate}/> }
+                help={ <TrashInfo greenUpStartDate={ greenUpStartDate } greenUpEndDate={ greenUpEndDate }/> }
                 searchTerm={ searchTerm }
                 search={ setSearchTerm }
                 userLocation={ userLocation }

--- a/components/disposal-site-selector/disposal-site-selector.js
+++ b/components/disposal-site-selector/disposal-site-selector.js
@@ -9,6 +9,7 @@ import { searchArray } from "../../libs/search";
 import SearchBar from "../search-bar";
 import TownListItem from "../town-list-item";
 import TrashCollectionSite from "../../models/trash-collection-site";
+import { greenUpEndDate, greenUpStartDate } from "../../libs/green-up-day-calucators";
 
 const searchableFields = ["name", "townName", "address", "townId"];
 
@@ -37,7 +38,7 @@ export const DisposalSiteSelector = ({ userLocation, townInfo }: PropsType): Rea
     return (
         <Fragment>
             <SearchBar
-                help={ <TrashInfo/> }
+                help={ <TrashInfo greenUpStartDate={greenUpStartDate} greenUpEndDate={greenUpEndDate}/> }
                 searchTerm={ searchTerm }
                 search={ setSearchTerm }
                 userLocation={ userLocation }

--- a/components/trash-info/trash-info.js
+++ b/components/trash-info/trash-info.js
@@ -1,20 +1,19 @@
 // @flow
 import React from "react";
 import { Text, View } from "react-native";
-import moment from "moment";
-import { getCurrentGreenUpDay } from "../../libs/green-up-day-calucators";
 
-const guStart = moment(getCurrentGreenUpDay()).subtract(1, "days");
-const guEnd = moment(getCurrentGreenUpDay()).add(4, "days");
+type PropsType = {
+    greenUpStartDate: string,
+    greenUpEndDate: string
+};
 
-
-export const TrashInfo = (): React$Element<any> => (
+export const TrashInfo = ({ greenUpStartDate, greenUpEndDate }: PropsType): React$Element<any> => (
     <View style={ { backgroundColor: "white", padding: 20, margin: 10 } }>
         <Text style={ { fontSize: 20 } }>
             { "Each town handles trash bags differently. Find the rules for your town" }
         </Text>
         <Text style={ { marginTop: 20, fontSize: 16 } }>
-            { `Trash bag tracking starts ${ guStart.format("dddd MM/DD/YYYY") } and ends ${ guEnd.format("dddd MM/DD/YYYY") }` }
+            { `Trash bag tracking starts ${ greenUpStartDate } and ends ${ greenUpEndDate }` }
         </Text>
 
     </View>

--- a/components/trash-info/trash-info.test.js
+++ b/components/trash-info/trash-info.test.js
@@ -4,6 +4,6 @@ import TrashInfo from "./index";
 import renderer from "react-test-renderer";
 
 it("renders correctly", () => {
-    const tree = renderer.create(<TrashInfo>Snapshot test!</TrashInfo>).toJSON();
+    const tree = renderer.create(<TrashInfo/>).toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/components/trash-info/trash-info.test.js
+++ b/components/trash-info/trash-info.test.js
@@ -2,8 +2,9 @@ import "react-native";
 import React from "react";
 import TrashInfo from "./index";
 import renderer from "react-test-renderer";
+import { greenUpEndDate, greenUpStartDate } from "../../libs/green-up-day-calucators";
 
 it("renders correctly", () => {
-    const tree = renderer.create(<TrashInfo/>).toJSON();
+    const tree = renderer.create(<TrashInfo greenUpStartDate={greenUpStartDate} greenUpEndDate={greenUpEndDate} />).toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/components/trash-info/trash-info.test.js
+++ b/components/trash-info/trash-info.test.js
@@ -5,6 +5,6 @@ import renderer from "react-test-renderer";
 import { greenUpEndDate, greenUpStartDate } from "../../libs/green-up-day-calucators";
 
 it("renders correctly", () => {
-    const tree = renderer.create(<TrashInfo greenUpStartDate={greenUpStartDate} greenUpEndDate={greenUpEndDate} />).toJSON();
+    const tree = renderer.create(<TrashInfo greenUpStartDate={ greenUpStartDate } greenUpEndDate={ greenUpEndDate } />).toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/libs/green-up-day-calucators.js
+++ b/libs/green-up-day-calucators.js
@@ -1,4 +1,6 @@
 // @flow
+import moment from "moment";
+
 // Green Up Day is always the first Saturday in May
 
 // Calculates the Green Up day for the provided year.
@@ -36,3 +38,5 @@ export const dateIsInCurrentEventWindow = (today?: TodayType): boolean => {
     return daysUntilGreenUpDay <= 2 && daysUntilGreenUpDay >= -3;
 };
 
+export const greenUpStartDate = moment(getCurrentGreenUpDay()).subtract(1, "days").format("dddd MM/DD/YYYY");
+export const greenUpEndDate = moment(getCurrentGreenUpDay()).add(4, "days").format("dddd MM/DD/YYYY");


### PR DESCRIPTION
The CI tests are still failing because the dates in the snapshot don't match:
![image](https://user-images.githubusercontent.com/1809882/77862331-b9190f00-71e8-11ea-9bb3-a22f546728c7.png)

This PR updates the `<TownInfo>` component so that it takes the dates as properties. This allows me (hopefully) to update the test to pass the expected dates to the component so that (hopefully) the test snapshot matches the component rendering. 

Of course, I won't know for sure until after I merge this and run it against CircleCI...