### PR TITLE
Login Screen keyboard issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "react-native-checkbox": "^2.0.0",
     "react-native-fs": "^2.16.1",
     "react-native-gesture-handler": "~1.6.0",
+    "react-native-hide-with-keyboard": "^1.2.1",
+    "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-linear-gradient": "~2.5.6",
     "react-native-maps": "0.26.1",
     "react-native-modal-datetime-picker": "^7.5.0",

--- a/screens/create-new-account-screen/index.js
+++ b/screens/create-new-account-screen/index.js
@@ -5,13 +5,12 @@ import {
     StyleSheet,
     SafeAreaView,
     TouchableWithoutFeedback,
-    Platform,
     Keyboard
 } from "react-native";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import CreateAccountForm from "../../components/create-account-form";
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import * as actionCreators from "../../action-creators/session-action-creators";
 import { defaultStyles } from "../../styles/default-styles";
 import { View } from "@shoutem/ui";
@@ -28,7 +27,7 @@ type PropsType = {
 
 
 const Index = ({ actions, createUserError }: PropsType): React$Element<any> => (
-    <KeyboardAwareScrollView style={{ backgroundColor: constants.colorBackgroundDark }}>
+    <KeyboardAwareScrollView style={ { backgroundColor: constants.colorBackgroundDark } }>
         <SafeAreaView style={ styles.container }>
             <TouchableWithoutFeedback onPress={ Keyboard.dismiss }>
                 <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, marginTop: 20, justifyContent: "flex-end" } }>

--- a/screens/create-new-account-screen/index.js
+++ b/screens/create-new-account-screen/index.js
@@ -6,12 +6,12 @@ import {
     SafeAreaView,
     TouchableWithoutFeedback,
     Platform,
-    KeyboardAvoidingView,
     Keyboard
 } from "react-native";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import CreateAccountForm from "../../components/create-account-form";
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import * as actionCreators from "../../action-creators/session-action-creators";
 import { defaultStyles } from "../../styles/default-styles";
 import { View } from "@shoutem/ui";
@@ -28,10 +28,7 @@ type PropsType = {
 
 
 const Index = ({ actions, createUserError }: PropsType): React$Element<any> => (
-    <KeyboardAvoidingView
-        behavior={ Platform.OS === "ios" ? "padding" : null }
-        style={ { flex: 1 } }
-    >
+    <KeyboardAwareScrollView style={{ backgroundColor: constants.colorBackgroundDark }}>
         <SafeAreaView style={ styles.container }>
             <TouchableWithoutFeedback onPress={ Keyboard.dismiss }>
                 <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, marginTop: 20, justifyContent: "flex-end" } }>
@@ -44,7 +41,7 @@ const Index = ({ actions, createUserError }: PropsType): React$Element<any> => (
                 </View>
             </TouchableWithoutFeedback>
         </SafeAreaView>
-    </KeyboardAvoidingView>
+    </KeyboardAwareScrollView>
 );
 
 

--- a/screens/login-screen/index.js
+++ b/screens/login-screen/index.js
@@ -7,15 +7,11 @@ import {
     Alert,
     Image,
     StyleSheet,
-    SafeAreaView,
-    TouchableWithoutFeedback,
-    Platform,
-    KeyboardAvoidingView,
-    Keyboard
+    SafeAreaView
 } from "react-native";
 import { View, Button, Text, Divider } from "@shoutem/ui";
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import HideWithKeyboard from 'react-native-hide-with-keyboard';
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import HideWithKeyboard from "react-native-hide-with-keyboard";
 import * as actionCreators from "../../action-creators/session-action-creators";
 import logo from "../../assets/images/gu-50-logo.png";
 import LoginForm from "../../components/login-form";
@@ -88,8 +84,8 @@ type PropsType = {
 };
 
 const Login = ({ actions, loginError, navigation }: PropsType): React$Element<any> => (
-        <SafeAreaView style={ styles.container }>
-            <KeyboardAwareScrollView>
+    <SafeAreaView style={ styles.container }>
+        <KeyboardAwareScrollView>
             { loginError
                 ? Alert.alert(
                     "",
@@ -103,52 +99,52 @@ const Login = ({ actions, loginError, navigation }: PropsType): React$Element<an
                     { cancelable: false }
                 ) : null
             }
-                <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, justifyContent: "flex-end" } }>
-                    <HideWithKeyboard>
-                        <View style={ styles.logo }>
-                            <Image source={ logo } style={ { height: 120, width: 120 } }/>
-                        </View>
-                    </HideWithKeyboard>
-                    <View style={ { width: "100%" } }>
-                        <LoginForm onButtonPress={ actions.loginWithEmailPassword }/>
-                        <Divider styleName="line"/>
-                        <View style={ { marginTop: 40 } } styleName="horizontal">
-                            <Button
-                                onPress={ () => {
-                                    navigation.navigate("ForgotPassword");
-                                } }
-                                style={ { paddingLeft: 20, paddingRight: 20 } }
-                                styleName="confirmation secondary"
-                            >
-                                <MaterialCommunityIcons
-                                    name={ "account-convert" }
-                                    size={ 25 }
-                                    style={ { marginRight: 10 } }
-                                    color="#FFF"
-                                />
-                                <Text>RESET PASSWORD</Text>
-                            </Button>
-                            <Button
-                                onPress={ () => {
-                                    navigation.navigate("CreateNewAccount");
-                                } }
-                                style={ { paddingLeft: 20, paddingRight: 20 } }
-                                styleName="confirmation secondary"
-                            >
-                                <MaterialCommunityIcons
-                                    name={ "account-plus" }
-                                    size={ 25 }
-                                    style={ { marginRight: 10 } }
-                                    color="#FFF"
-                                />
-                                <Text style={ styles.buttonText }>CREATE ACCOUNT</Text>
-                            </Button>
-                        </View>
+            <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, justifyContent: "flex-end" } }>
+                <HideWithKeyboard>
+                    <View style={ styles.logo }>
+                        <Image source={ logo } style={ { height: 120, width: 120 } }/>
                     </View>
-                    <View style={ { flex: 1 } }/>
+                </HideWithKeyboard>
+                <View style={ { width: "100%" } }>
+                    <LoginForm onButtonPress={ actions.loginWithEmailPassword }/>
+                    <Divider styleName="line"/>
+                    <View style={ { marginTop: 40 } } styleName="horizontal">
+                        <Button
+                            onPress={ () => {
+                                navigation.navigate("ForgotPassword");
+                            } }
+                            style={ { paddingLeft: 20, paddingRight: 20 } }
+                            styleName="confirmation secondary"
+                        >
+                            <MaterialCommunityIcons
+                                name={ "account-convert" }
+                                size={ 25 }
+                                style={ { marginRight: 10 } }
+                                color="#FFF"
+                            />
+                            <Text>RESET PASSWORD</Text>
+                        </Button>
+                        <Button
+                            onPress={ () => {
+                                navigation.navigate("CreateNewAccount");
+                            } }
+                            style={ { paddingLeft: 20, paddingRight: 20 } }
+                            styleName="confirmation secondary"
+                        >
+                            <MaterialCommunityIcons
+                                name={ "account-plus" }
+                                size={ 25 }
+                                style={ { marginRight: 10 } }
+                                color="#FFF"
+                            />
+                            <Text style={ styles.buttonText }>CREATE ACCOUNT</Text>
+                        </Button>
+                    </View>
                 </View>
-                </KeyboardAwareScrollView>
-        </SafeAreaView>
+                <View style={ { flex: 1 } }/>
+            </View>
+        </KeyboardAwareScrollView>
+    </SafeAreaView>
 
 );
 

--- a/screens/login-screen/index.js
+++ b/screens/login-screen/index.js
@@ -14,6 +14,8 @@ import {
     Keyboard
 } from "react-native";
 import { View, Button, Text, Divider } from "@shoutem/ui";
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import HideWithKeyboard from 'react-native-hide-with-keyboard';
 import * as actionCreators from "../../action-creators/session-action-creators";
 import logo from "../../assets/images/gu-50-logo.png";
 import LoginForm from "../../components/login-form";
@@ -86,12 +88,8 @@ type PropsType = {
 };
 
 const Login = ({ actions, loginError, navigation }: PropsType): React$Element<any> => (
-    <KeyboardAvoidingView
-        behavior={ Platform.OS === "ios" ? "padding" : null }
-        style={ { flex: 1 } }
-    >
         <SafeAreaView style={ styles.container }>
-
+            <KeyboardAwareScrollView>
             { loginError
                 ? Alert.alert(
                     "",
@@ -105,11 +103,12 @@ const Login = ({ actions, loginError, navigation }: PropsType): React$Element<an
                     { cancelable: false }
                 ) : null
             }
-            <TouchableWithoutFeedback onPress={ Keyboard.dismiss }>
                 <View style={ { paddingLeft: 20, paddingRight: 20, flex: 1, justifyContent: "flex-end" } }>
-                    <View style={ styles.logo }>
-                        <Image source={ logo } style={ { height: 120, width: 120 } }/>
-                    </View>
+                    <HideWithKeyboard>
+                        <View style={ styles.logo }>
+                            <Image source={ logo } style={ { height: 120, width: 120 } }/>
+                        </View>
+                    </HideWithKeyboard>
                     <View style={ { width: "100%" } }>
                         <LoginForm onButtonPress={ actions.loginWithEmailPassword }/>
                         <Divider styleName="line"/>
@@ -148,9 +147,8 @@ const Login = ({ actions, loginError, navigation }: PropsType): React$Element<an
                     </View>
                     <View style={ { flex: 1 } }/>
                 </View>
-            </TouchableWithoutFeedback>
+                </KeyboardAwareScrollView>
         </SafeAreaView>
-    </KeyboardAvoidingView>
 
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16002,6 +16002,11 @@ react-native-gesture-responder@0.1.1:
   dependencies:
     react-timer-mixin "^0.13.3"
 
+react-native-hide-with-keyboard@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-hide-with-keyboard/-/react-native-hide-with-keyboard-1.2.1.tgz#9e7b03832e8b2b18e999646dc25686487ce72974"
+  integrity sha512-O3aI0TkfHLaWO3bjO8bDXgOZ/R/K+Ca8CaXOyHJT71eQlyp2CnycUIa/qHUGkXbVpqjt0hZC7k+MUAer82UOaQ==
+
 react-native-image-picker@^0.26.7:
   version "0.26.10"
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.26.10.tgz#0bb9ab928984948c67aee0b9e64216bee007a9fc"
@@ -16011,6 +16016,19 @@ react-native-image-resizer@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-image-resizer/-/react-native-image-resizer-1.2.1.tgz#3dd706576f49f4f62efab8bc0e6498927068d621"
   integrity sha512-2H+mTCsFKUufy83u1vJKff6Wj3T6FQTo2vvdQuxD9XHai5ZcHO2oCMkFhQm8EhNd2Pc1ongrqs9i1OP/En/p3A==
+
+react-native-iphone-x-helper@^1.0.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
+  integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+
+react-native-keyboard-aware-scroll-view@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.1.tgz#9e54b565a5f19b30bed12221d48921781f7630af"
+  integrity sha512-tBZ8rmjELN0F6t5UBp5CW3NYmZXgVnJSzVCssv/OqG2t6kiB+OUTqxNvUP24K+HARX4H+XaW0aEJSFQkQCv6KA==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
 
 react-native-lightbox@shoutem/react-native-lightbox#v0.7.2:
   version "0.7.2"


### PR DESCRIPTION
Previously the keyboard was obscuring the login screen on several devices. I'm attempting to address this with two fixes:
- A ["keyboard-aware" scrolling view](https://github.com/APSL/react-native-keyboard-aware-scroll-view) with better scrolling for older iOS devices
- A wrapper around the Green Up logo [that hides the logo when the keyboard comes up](https://www.npmjs.com/package/react-native-hide-with-keyboard)

I tested this approach has been tested on:
- iPhone 5
- Google Pixel 3a
- iPhone XR (simulator)

| Android 10     | iPhone 5        | iPhone XR        | 
| ------------- |:-------------:|:-------------:|
| <img src="https://i.gyazo.com/715f3cfdf850d149bc1183997b1b911a.gif" width="250"/>   | <img src="https://i.gyazo.com/d8e4882721b77623c2eab43fb9830ccd.gif" width=250/> | <img src="https://i.gyazo.com/1e69b81a55c5578188fef4bbcd56db9e.gif" width=250/> |

Depending on the device, the experience can be a _little_ more choppy than I'd like. If we want to make it smoother by [using the keyboard module](https://www.freecodecamp.org/news/how-to-make-your-react-native-app-respond-gracefully-when-the-keyboard-pops-up-7442c1535580/) and writing some keyboard event handlers that animate the removal of the logo. But I'm not going to attempt that as part of this PR.