### PR TITLE
QA friendly bag drop screen

### DIFF
--- a/components/trash-drop-form/trash-drop-form.js
+++ b/components/trash-drop-form/trash-drop-form.js
@@ -22,6 +22,7 @@ import { FontAwesome, MaterialCommunityIcons } from "@expo/vector-icons";
 import TagToggle from "../../components/tag-toggle";
 import { isInGreenUpWindow } from "../../libs/green-up-day-calucators"; // TODO: Add out of window warning
 import { findTownIdByCoordinates } from "../../libs/geo-helpers";
+import { isProductionEnv } from "../../libs/app-utils";
 
 type LocationType = { id: string, name: string, coordinates: { longitude: number, latitude: number }, error: any };
 
@@ -193,7 +194,7 @@ export const TrashDropForm = ({ teamOptions, onSave, currentUser, townData, tras
                 R.cond(
                     [
                         [
-                            () => (!(isInGreenUpWindow())),
+                            () => (!(isInGreenUpWindow()) && isProductionEnv()),
                             () => (
                                 <Fragment>
                                     <SafeAreaView style={ {
@@ -206,14 +207,8 @@ export const TrashDropForm = ({ teamOptions, onSave, currentUser, townData, tras
                                         padding: 50
 
                                     } }>
-                                        <Text style={ { color: "white", paddingBottom: 20 } }>
-                                            You cannot collect trash until the Monday before Green Up Day!
-                                        </Text>
-                                        <Text style={ { color: "white", paddingBottom: 20 } }>
-                                            We want to keep the score fair!
-                                        </Text>
                                         <Text style={ { color: "white" } }>
-                                            Check back to this screen when Green Up week starts to tag your bags!
+                                            Come back to this screen during Green Up week to record your bags!
                                         </Text>
                                     </SafeAreaView>
                                 </Fragment>

--- a/libs/app-utils.js
+++ b/libs/app-utils.js
@@ -1,0 +1,29 @@
+import { firebaseConfig } from "../firebase-config.js";
+
+/**
+ * "util" files become natoriously messy - please help keep our code clean
+ * 
+ * If you're thinking of adding something here, please make sure it is something that is 
+ * relevant anywhere in the app. If it is not, please create a new file and give it a 
+ * descriptive name to help keep the directory structure readable and intuitive. 
+ */
+
+
+/** Returns a boolean true if the app is running in the production environment.
+ */
+export function isProductionEnv(){
+    return getEnvString() === 'Prod';
+}
+
+/**
+ * Returns a string of 'QA', 'Dev', 'Prod', or 'unknown' indicating which environment the
+ * app is running under.
+ */
+export function getEnvString(){
+    switch(firebaseConfig.projectId){
+        case 'greenupvermont-qa': return 'QA';
+        case 'greenupvermont-dev': return 'Dev';
+        case 'greenupvermont-de02b': return 'Prod';
+        default: return 'unknown';
+    }
+}


### PR DESCRIPTION
The idea is that on Production people should not be able to drop bags ahead of Green Up day, but the QA team should be able to use it without restrictions anytime.