### PR TITLE
Fix: Node version typo in setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ Get your own Firebase database here (https://firebase.google.com/) or, if you wa
 
 3) **Install Project Dependencies**:
 ```bash
-nvm install v12.6.1
-nvm use v12.6.1
-# optional nvm alias green-up v12.6.1
+nvm install v12.16.1
+nvm use v12.16.1
+# optional nvm alias green-up v12.16.1
 npm install
 npm install -g expo-cli #Currently using version , but the latest version is ok
 npm install -g flow


### PR DESCRIPTION
Refer to https://github.com/codeforbtv/green-up-app/blob/master/package.json#L29 for real version (12.16.1)

@nfloersch Could we clean out the old PRs here as well please?